### PR TITLE
Fix error on double click

### DIFF
--- a/axe/gui_qt.py
+++ b/axe/gui_qt.py
@@ -399,7 +399,7 @@ class VisualTree(qtw.QTreeWidget):
                     ## if item.childCount() > 0:
                         ## edit = False
         if edit:
-            self.parent.edit()
+            self.parent.edit_item(item)
         else:
             event.ignore()
 


### PR DESCRIPTION
Fix the error:
```Traceback (most recent call last):
  File "/home/wave/repositories/axe/axe/gui_qt.py", line 402, in mouseDoubleClickEvent
    self.parent.edit()
AttributeError: 'Gui' object has no attribute 'edit'
```